### PR TITLE
Allow to publish Buffers

### DIFF
--- a/src/mqtt.service.ts
+++ b/src/mqtt.service.ts
@@ -32,11 +32,8 @@ export class MqttService {
     });
   }
 
-  publish(topic: string, message: string | Buffer | object, opts?: IClientPublishOptions): Promise<Packet> {
+  publish(topic: string, message: string | Buffer, opts?: IClientPublishOptions): Promise<Packet> {
     return new Promise<Packet>((resolve, reject) => {
-      if (typeof message === 'object') {
-        message = JSON.stringify(message);
-      }
       this.client.publish(topic, message, opts || null, (error, packet) => {
         if (error) {
           reject(error);


### PR DESCRIPTION
# The problem
MQTT.js by default allows to publish binary data via Node's Buffer. However, `MqttService` accepted generic "object" as parameter. Objects were automatically transformed into JSON strings before passing into MQTT publish function. 

That way, Buffer was transformed into string `{ type: "Buffer", data: [...] }`.

# The solution

This PR removes the conversion.

# Side effect

Conversion is up to the user, whatever is passed into `MqttService` will be sent.